### PR TITLE
Fixes for V1 ImmyBot integration.

### DIFF
--- a/Examples/Immense.RemoteControl.Examples.WindowsDesktopExample/Program.cs
+++ b/Examples/Immense.RemoteControl.Examples.WindowsDesktopExample/Program.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Immense.RemoteControl.Desktop.Shared.Startup;
 using Immense.RemoteControl.Desktop.Shared.Services;
+using System.Windows;
 
 var services = new ServiceCollection();
 services.AddRemoteControlWindows(config =>
@@ -39,8 +40,15 @@ Console.CancelKeyPress += async (s, e) =>
 };
 
 var appState = provider.GetRequiredService<IAppState>();
-Console.WriteLine("Unattended session ready at: ");
-Console.WriteLine($"https://localhost:7024/RemoteControl/Viewer?mode=Unattended&sessionId={appState.SessionId}&accessKey={appState.AccessKey}");
+Console.WriteLine("Unattended session ready at (copied to clipboard): ");
+var url = $"https://localhost:7024/RemoteControl/Viewer?mode=Unattended&sessionId={appState.SessionId}&accessKey={appState.AccessKey}";
+Console.WriteLine(url);
+var thread = new Thread(() =>
+{
+    Clipboard.SetText(url);
+});
+thread.SetApartmentState(ApartmentState.STA);
+thread.Start();
 
 Console.WriteLine("Press Ctrl + C to exit.");
 var dispatcher = provider.GetRequiredService<IWindowsUiDispatcher>();

--- a/Immense.RemoteControl.Desktop.Native/Windows/Kernel32.cs
+++ b/Immense.RemoteControl.Desktop.Native/Windows/Kernel32.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 
 namespace Immense.RemoteControl.Desktop.Native.Windows;
@@ -10,6 +10,9 @@ public static class Kernel32
 
     [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
     public static extern IntPtr GetCommandLine();
+
+    [DllImport("kernel32.dll")]
+    public static extern IntPtr GetConsoleWindow();
 
     [return: MarshalAs(UnmanagedType.Bool)]
     [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
@@ -23,6 +26,7 @@ public static class Kernel32
 
     [DllImport("kernel32.dll")]
     public static extern uint WTSGetActiveConsoleSessionId();
+
     /// <summary>
     /// contains information about the current state of both physical and virtual memory, including extended memory
     /// </summary>

--- a/Immense.RemoteControl.Desktop.Native/Windows/User32.cs
+++ b/Immense.RemoteControl.Desktop.Native/Windows/User32.cs
@@ -1044,6 +1044,23 @@ public static class User32
         IDTRYAGAIN = 10,
         IDYES = 6,
     }
+    public enum SW
+    {
+        SW_HIDE = 0,
+        SW_SHOWNORMAL = 1,
+        SW_NORMAL = 1,
+        SW_SHOWMINIMIZED = 2,
+        SW_SHOWMAXIMIZED = 3,
+        SW_MAXIMIZE = 3,
+        SW_SHOWNOACTIVATE = 4,
+        SW_SHOW = 5,
+        SW_MINIMIZE = 6,
+        SW_SHOWMINNOACTIVE = 7,
+        SW_SHOWNA = 8,
+        SW_RESTORE = 9,
+        SW_SHOWDEFAULT = 10,
+        SW_MAX = 10
+    }
     public enum VkMapType : uint
     {
         MAPVK_VK_TO_VSC = 0,

--- a/Immense.RemoteControl.Desktop.Native/Windows/Win32Interop.cs
+++ b/Immense.RemoteControl.Desktop.Native/Windows/Win32Interop.cs
@@ -246,4 +246,20 @@ public class Win32Interop
             return false;
         }
     }
+
+    public static void SetConsoleWindowVisibility(bool isVisible)
+    {
+        var handle = Kernel32.GetConsoleWindow();
+
+        if (isVisible)
+        {
+            ShowWindow(handle, (int)SW.SW_SHOW);
+        }
+        else
+        {
+            ShowWindow(handle, (int)SW.SW_HIDE);
+        }
+
+        Kernel32.CloseHandle(handle);
+    }
 }

--- a/Immense.RemoteControl.Desktop.Windows/Services/ShutdownServiceWin.cs
+++ b/Immense.RemoteControl.Desktop.Windows/Services/ShutdownServiceWin.cs
@@ -1,4 +1,4 @@
-﻿using Immense.RemoteControl.Desktop.Shared.Abstractions;
+using Immense.RemoteControl.Desktop.Shared.Abstractions;
 using Immense.RemoteControl.Desktop.Shared.Services;
 using Immense.RemoteControl.Desktop.UI.WPF.Services;
 using Microsoft.Extensions.Logging;
@@ -31,11 +31,20 @@ public class ShutdownServiceWin : IShutdownService
             _logger.LogInformation("Exiting process ID {procId}.", Environment.ProcessId);
             await TryDisconnectViewers();
             Application.Exit();
-            _dispatcher.InvokeWpf(_dispatcher.CurrentApp.Shutdown);
+            try
+            {
+                _dispatcher.InvokeWpf(_dispatcher.CurrentApp.Shutdown);
+            }
+            // This is expected to happen sometimes.
+            catch (TaskCanceledException)
+            {
+                Environment.Exit(0);
+            }
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error while shutting down.");
+            Environment.Exit(1);
         }
     }
 

--- a/Immense.RemoteControl.Server/Hubs/ViewerHub.cs
+++ b/Immense.RemoteControl.Server/Hubs/ViewerHub.cs
@@ -75,11 +75,10 @@ public class ViewerHub : Hub
             return Result.Fail("Only available in unattended mode.");
         }
 
+        SessionInfo.ViewerList.Remove(Context.ConnectionId);
         await _desktopHub.Clients.Client(SessionInfo.DesktopConnectionId).SendAsync("ViewerDisconnected", Context.ConnectionId);
 
-        SessionInfo.ViewerList.Remove(Context.ConnectionId);
         SessionInfo = SessionInfo.CreateNew();
-
         _desktopSessionCache.AddOrUpdate($"{SessionInfo.UnattendedSessionId}", SessionInfo);
 
         await _hubEvents.ChangeWindowsSession(SessionInfo, Context.ConnectionId, targetWindowsSession);

--- a/Immense.RemoteControl.Server/Models/RemoteControlSession.cs
+++ b/Immense.RemoteControl.Server/Models/RemoteControlSession.cs
@@ -43,7 +43,7 @@ public class RemoteControlSession : IDisposable
     /// <summary>
     /// Contains a collection of viewer SignalR connection IDs.
     /// </summary>
-    public HashSet<string> ViewerList { get; } = new();
+    public HashSet<string> ViewerList { get; private set; } = new();
 
     public bool ViewOnly { get; set; }
     /// <summary>
@@ -62,7 +62,7 @@ public class RemoteControlSession : IDisposable
         clone.Created = DateTimeOffset.Now;
         clone.UnattendedSessionId = Guid.NewGuid();
         clone.AccessKey = RandomGenerator.GenerateAccessKey();
-        clone.ViewerList.Clear();
+        clone.ViewerList = new();
         clone.ViewOnly = false;
         return clone;
     }

--- a/Immense.RemoteControl.Server/Services/DesktopHubSessionCache.cs
+++ b/Immense.RemoteControl.Server/Services/DesktopHubSessionCache.cs
@@ -1,4 +1,4 @@
-﻿using Immense.RemoteControl.Server.Models;
+using Immense.RemoteControl.Server.Models;
 using Immense.RemoteControl.Shared.Services;
 using Microsoft.Extensions.Logging;
 using System.Collections.Concurrent;
@@ -72,7 +72,10 @@ internal class DesktopHubSessionCache : IDesktopHubSessionCache
                 session.Value.Created < _systemTime.Now.AddMinutes(-1))
             {
                 _logger.LogWarning("Removing expired session: {session}", JsonSerializer.Serialize(session.Value));
-                _sessions.TryRemove(session.Key, out _);
+                if (_sessions.TryRemove(session.Key, out var expiredSession))
+                {
+                    expiredSession.Dispose();
+                }
             }
         }
         return Task.CompletedTask;

--- a/Immense.RemoteControl.sln
+++ b/Immense.RemoteControl.sln
@@ -38,6 +38,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".build", ".build", "{CE8FF8
 		.build\Pre-Build.ps1 = .build\Pre-Build.ps1
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Immense.RemoteControl.Desktop.Native", "Immense.RemoteControl.Desktop.Native\Immense.RemoteControl.Desktop.Native.csproj", "{2483EFAC-826E-4529-ABF0-863C91418E29}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -80,6 +82,10 @@ Global
 		{9EACF89B-0E6F-480F-BB8F-0EB1E53F9019}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9EACF89B-0E6F-480F-BB8F-0EB1E53F9019}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9EACF89B-0E6F-480F-BB8F-0EB1E53F9019}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2483EFAC-826E-4529-ABF0-863C91418E29}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2483EFAC-826E-4529-ABF0-863C91418E29}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2483EFAC-826E-4529-ABF0-863C91418E29}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2483EFAC-826E-4529-ABF0-863C91418E29}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Changes:

- Copy session URL to clipboard in example project.
- Add p/invokes for hiding the console window.
- Handle `TaskCanceledException` in `ShutdownServiceWin`, which was preventing app from shutting down.
  -  Add `Environment.Exit` fallbacks.
- Create new `HashSet` instance for ViewerList when cloning RemoteControlSession.
- Dispose RemoteControlSession when removing expired one.