### PR TITLE
Fixes for WindowsSessionType and RequireConsent.

### DIFF
--- a/Immense.RemoteControl.Server/Hubs/ViewerHub.cs
+++ b/Immense.RemoteControl.Server/Hubs/ViewerHub.cs
@@ -107,6 +107,11 @@ public class ViewerHub : Hub
             yield break;
         }
 
+        // At this point, if RequireConsent is enabled, the user has accepted the request.
+        // We can turn it off for the remainder of the session so that reconnects and session
+        // switches can happen without re-prompting.
+        SessionInfo.RequireConsent = false;
+
         try
         {
             await foreach (var chunk in signaler.Stream)

--- a/Immense.RemoteControl.Server/wwwroot/src/Enums/WindowsSessionType.ts
+++ b/Immense.RemoteControl.Server/wwwroot/src/Enums/WindowsSessionType.ts
@@ -1,4 +1,4 @@
 ﻿export enum WindowsSessionType {
-    Console = 0,
-    RDP = 1
+    Console = 1,
+    RDP = 2
 }


### PR DESCRIPTION
- Updated the `WindowsSessionType` enum in the viewer to reflect the new values from the previous PR.
- Set `RequireConsent` to false for the remainder of the session after user accepts.
  - This allows reconnects and session switching to happen without re-prompting.
  - It only affects the current session.