### PR TITLE
Close all pop-ups when the viewer's menu is hidden.

### DIFF
--- a/Immense.RemoteControl.Server/wwwroot/src/UI.ts
+++ b/Immense.RemoteControl.Server/wwwroot/src/UI.ts
@@ -139,6 +139,7 @@ export function ToggleConnectUI(shown: boolean) {
         AudioButton.classList.remove("toggled");
         WorkAreaGrid.style.display = "none";
         BackgroundLayers.classList.remove("d-none");
+        CloseAllPopupMenus(null);
     }
     else {
         ConnectBox.style.display = "none";


### PR DESCRIPTION
Close all pop-ups when the viewer's menu is hidden (e.g. when disconected or switching sessions).  So we don't have a state transitions that looks like the below.

![image](https://github.com/immense/RemoteControl/assets/20995508/0f78c5e8-ba87-4340-9563-35798da41177)
