### PR TITLE
Add StreamID to session requested message

### DIFF
--- a/Immense.RemoteControl.Server/Hubs/ViewerHub.cs
+++ b/Immense.RemoteControl.Server/Hubs/ViewerHub.cs
@@ -189,6 +189,7 @@ public class ViewerHub : Hub
         var logMessage = $"Remote control session requested.  " +
                             $"Login ID (if logged in): {Context.User?.Identity?.Name}.  " +
                             $"Machine Name: {SessionInfo.MachineName}.  " +
+                            $"Stream ID: {SessionInfo.StreamId}.  " +
                             $"Requester Name (if specified): {RequesterDisplayName}.  " +
                             $"Connection ID: {Context.ConnectionId}. User ID: {Context.UserIdentifier}.  " +
                             $"Screen Caster Connection ID: {SessionInfo.DesktopConnectionId}.  " +


### PR DESCRIPTION
Added the StreamID to the session requested log output. With this information you can find the start and the end of the session in the logs.