### PR TITLE
Initial implementation of server-side recording.

### DIFF
--- a/Examples/Immense.RemoteControl.Examples.ServerExample/Options/AppSettingsOptions.cs
+++ b/Examples/Immense.RemoteControl.Examples.ServerExample/Options/AppSettingsOptions.cs
@@ -1,0 +1,8 @@
+﻿namespace Immense.RemoteControl.Examples.ServerExample.Options;
+
+public class AppSettingsOptions
+{
+    public const string KeyName = "AppSettings";
+
+    public bool ShouldRecordSessions { get; init; }
+}

--- a/Examples/Immense.RemoteControl.Examples.ServerExample/Program.cs
+++ b/Examples/Immense.RemoteControl.Examples.ServerExample/Program.cs
@@ -1,4 +1,6 @@
+using Immense.RemoteControl.Examples.ServerExample.Options;
 using Immense.RemoteControl.Examples.ServerExample.Services;
+using Immense.RemoteControl.Server.Abstractions;
 using Immense.RemoteControl.Server.Extensions;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -12,7 +14,12 @@ builder.Services.AddRemoteControlServer(config =>
     config.AddHubEventHandler<HubEventHandler>();
     config.AddViewerAuthorizer<ViewerAuthorizer>();
     config.AddViewerPageDataProvider<ViewerPageDataProvider>();
+    config.AddViewerOptionsProvider<ViewerOptionsProvider>();
+    config.AddSessionRecordingSink<SessionRecordingSink>();
 });
+
+builder.Services.Configure<AppSettingsOptions>(
+    builder.Configuration.GetSection(AppSettingsOptions.KeyName));
 
 var app = builder.Build();
 

--- a/Examples/Immense.RemoteControl.Examples.ServerExample/Services/SessionRecordingSink.cs
+++ b/Examples/Immense.RemoteControl.Examples.ServerExample/Services/SessionRecordingSink.cs
@@ -1,0 +1,54 @@
+﻿using Immense.RemoteControl.Server.Abstractions;
+using Immense.RemoteControl.Server.Models;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Immense.RemoteControl.Examples.ServerExample.Services;
+
+public class SessionRecordingSink : ISessionRecordingSink
+{
+    private readonly IWebHostEnvironment _hostingEnv;
+
+    public SessionRecordingSink(IWebHostEnvironment hostingEnv)
+    {
+        _hostingEnv = hostingEnv;
+    }
+
+    public async Task SinkWebmStream(
+        IAsyncEnumerable<byte[]> webmStream, 
+        HubCallerContext hubCallerContext, 
+        RemoteControlSession session)
+    {
+        try
+        {
+            var appData = _hostingEnv.IsDevelopment() ?
+                Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "App_Data") :
+                Path.Combine(_hostingEnv.ContentRootPath, "App_Data");
+
+            var recordingDir = Path.Combine(
+                appData,
+                "Recordings",
+                $"{DateTimeOffset.Now:yyyy-MM-dd}");
+
+            _ = Directory.CreateDirectory(recordingDir);
+
+            var fileName = 
+                $"{hubCallerContext.User?.Identity?.Name ?? "UnknownUser"}_" +
+                $"{DateTimeOffset.Now:yyyyMMdd_HHmmssfff}.webm";
+
+            using var fs = new FileStream(Path.Combine(recordingDir, fileName), FileMode.Create);
+
+            await foreach (var chunk in webmStream)
+            {
+                await fs.WriteAsync(chunk);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Log info.
+        }
+        catch (Exception)
+        {
+            // Log error.
+        }
+    }
+}

--- a/Examples/Immense.RemoteControl.Examples.ServerExample/Services/SessionRecordingSink.cs
+++ b/Examples/Immense.RemoteControl.Examples.ServerExample/Services/SessionRecordingSink.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.SignalR;
 
 namespace Immense.RemoteControl.Examples.ServerExample.Services;
 
+// This is just a demo implementation.
 public class SessionRecordingSink : ISessionRecordingSink
 {
     private readonly IWebHostEnvironment _hostingEnv;

--- a/Examples/Immense.RemoteControl.Examples.ServerExample/Services/ViewerOptionsProvider.cs
+++ b/Examples/Immense.RemoteControl.Examples.ServerExample/Services/ViewerOptionsProvider.cs
@@ -1,0 +1,30 @@
+﻿using Immense.RemoteControl.Examples.ServerExample.Options;
+using Immense.RemoteControl.Server.Abstractions;
+using Immense.RemoteControl.Server.Models;
+using Immense.RemoteControl.Shared.Models;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Options;
+
+namespace Immense.RemoteControl.Examples.ServerExample.Services;
+
+public class ViewerOptionsProvider : IViewerOptionsProvider
+{
+    private readonly IOptionsMonitor<AppSettingsOptions> _appSettings;
+
+    public ViewerOptionsProvider(IOptionsMonitor<AppSettingsOptions> appSettings)
+    {
+        _appSettings = appSettings;
+    }
+
+    public Task<RemoteControlViewerOptions> GetViewerOptionsAsync(
+        HubCallerContext hubCallerContext, 
+        RemoteControlSession session)
+    {
+        var options = new RemoteControlViewerOptions()
+        {
+            ShouldRecordSession = _appSettings.CurrentValue.ShouldRecordSessions
+        };
+
+        return Task.FromResult(options);
+    }
+}

--- a/Examples/Immense.RemoteControl.Examples.ServerExample/appsettings.Development.json
+++ b/Examples/Immense.RemoteControl.Examples.ServerExample/appsettings.Development.json
@@ -5,5 +5,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "AppSettings": {
+    "ShouldRecordSessions": true
   }
 }

--- a/Examples/Immense.RemoteControl.Examples.ServerExample/appsettings.json
+++ b/Examples/Immense.RemoteControl.Examples.ServerExample/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "AppSettings": {
+    "ShouldRecordSessions":  false
+  }
 }

--- a/Immense.RemoteControl.Server/Abstractions/ISessionRecordingSink.cs
+++ b/Immense.RemoteControl.Server/Abstractions/ISessionRecordingSink.cs
@@ -1,0 +1,28 @@
+﻿using Immense.RemoteControl.Server.Models;
+using Microsoft.AspNetCore.SignalR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Immense.RemoteControl.Server.Abstractions;
+
+/// <summary>
+/// The service is responsible for storing session recordings.
+/// </summary>
+public interface ISessionRecordingSink
+{
+    /// <summary>
+    /// Sink a live webm stream to persistent storage. 
+    /// The HubCallerContext is that of the viewer.
+    /// </summary>
+    /// <param name="webmStream"></param>
+    /// <param name="hubCallerContext"></param>
+    /// <param name="session"></param>
+    /// <returns></returns>
+    Task SinkWebmStream(
+        IAsyncEnumerable<byte[]> webmStream,
+        HubCallerContext hubCallerContext,
+        RemoteControlSession session);
+}

--- a/Immense.RemoteControl.Server/Abstractions/IViewerOptionsProvider.cs
+++ b/Immense.RemoteControl.Server/Abstractions/IViewerOptionsProvider.cs
@@ -1,0 +1,20 @@
+﻿using Immense.RemoteControl.Server.Models;
+using Immense.RemoteControl.Shared.Models;
+using Microsoft.AspNetCore.SignalR;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Immense.RemoteControl.Server.Abstractions;
+
+/// <summary>
+/// Provides options related to how the viewer front-end should behave.
+/// </summary>
+public interface IViewerOptionsProvider
+{
+    Task<RemoteControlViewerOptions> GetViewerOptionsAsync(
+        HubCallerContext hubCallerContext,
+        RemoteControlSession session);
+}

--- a/Immense.RemoteControl.Server/Areas/RemoteControl/Pages/Viewer.cshtml
+++ b/Immense.RemoteControl.Server/Areas/RemoteControl/Pages/Viewer.cshtml
@@ -90,12 +90,6 @@
             File Transfer
         </button>
 
-        <button id="recordSessionButton"
-                title="Record session as a WEBM video in the browser.">
-            <i class="fas fa-record-vinyl"></i>
-            Record
-        </button>
-
         <button id="inviteButton"
                 title="Copy a link that lets another person view the remote screen.">
             <i class="fas fa-user-plus"></i>

--- a/Immense.RemoteControl.Server/Extensions/RemoteControlServerBuilder.cs
+++ b/Immense.RemoteControl.Server/Extensions/RemoteControlServerBuilder.cs
@@ -14,12 +14,28 @@ public interface IRemoteControlServerBuilder
         where T : class, IHubEventHandler;
 
     /// <summary>
+    /// Adds your implementation of <see cref="ISessionRecordingSink"/> to the
+    /// DI container as a singleton.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    void AddSessionRecordingSink<T>()
+        where T : class, ISessionRecordingSink;
+
+    /// <summary>
     /// Adds your implementation of <see cref="IViewerAuthorizer"/> to the
     /// DI container as a scoped service.
     /// </summary>
     /// <typeparam name="T"></typeparam>
     void AddViewerAuthorizer<T>()
         where T : class, IViewerAuthorizer;
+
+    /// <summary>
+    /// Adds your implementation of <see cref="IViewerOptionsProvider"/> to the
+    /// DI container as a singleton.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    void AddViewerOptionsProvider<T>()
+        where T : class, IViewerOptionsProvider;
 
     /// <summary>
     /// Adds your implementation of <see cref="IViewerPageDataProvider"/> to the
@@ -45,14 +61,26 @@ internal class RemoteControlServerBuilder : IRemoteControlServerBuilder
         _services.AddSingleton<IHubEventHandler, T>();
     }
 
-    public void AddViewerAuthorizer<T>() 
-        where T : class, IViewerAuthorizer
+    public void AddSessionRecordingSink<T>()
+        where T : class, ISessionRecordingSink
+    {
+        _services.AddSingleton<ISessionRecordingSink, T>();
+    }
+
+    public void AddViewerAuthorizer<T>()
+            where T : class, IViewerAuthorizer
     {
         _services.AddScoped<IViewerAuthorizer, T>();
     }
 
-    public void AddViewerPageDataProvider<T>() 
-        where T : class, IViewerPageDataProvider
+    public void AddViewerOptionsProvider<T>()
+        where T : class, IViewerOptionsProvider
+    {
+        _services.AddSingleton<IViewerOptionsProvider, T>();
+    }
+
+    public void AddViewerPageDataProvider<T>()
+            where T : class, IViewerPageDataProvider
     {
         _services.AddScoped<IViewerPageDataProvider, T>();
     }
@@ -63,7 +91,9 @@ internal class RemoteControlServerBuilder : IRemoteControlServerBuilder
         {
             typeof(IHubEventHandler),
             typeof(IViewerAuthorizer),
-            typeof(IViewerPageDataProvider)
+            typeof(IViewerPageDataProvider),
+            typeof(ISessionRecordingSink),
+            typeof(IViewerOptionsProvider)
         };
 
         foreach (var type in serviceTypes)

--- a/Immense.RemoteControl.Server/Hubs/ViewerHub.cs
+++ b/Immense.RemoteControl.Server/Hubs/ViewerHub.cs
@@ -3,6 +3,7 @@ using Immense.RemoteControl.Server.Filters;
 using Immense.RemoteControl.Server.Models;
 using Immense.RemoteControl.Server.Services;
 using Immense.RemoteControl.Shared;
+using Immense.RemoteControl.Shared.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
@@ -13,6 +14,8 @@ namespace Immense.RemoteControl.Server.Hubs;
 public class ViewerHub : Hub
 {
     private readonly IHubContext<DesktopHub> _desktopHub;
+    private readonly IViewerOptionsProvider _viewerOptionsProvider;
+    private readonly ISessionRecordingSink _sessionRecordingSink;
     private readonly IDesktopHubSessionCache _desktopSessionCache;
     private readonly IHubEventHandler _hubEvents;
     private readonly ILogger<ViewerHub> _logger;
@@ -23,12 +26,16 @@ public class ViewerHub : Hub
         IDesktopHubSessionCache desktopSessionCache,
         IDesktopStreamCache streamCache,
         IHubContext<DesktopHub> desktopHub,
+        IViewerOptionsProvider viewerOptionsProvider,
+        ISessionRecordingSink sessionRecordingSink,
         ILogger<ViewerHub> logger)
     {
         _hubEvents = hubEvents;
         _desktopSessionCache = desktopSessionCache;
         _streamCache = streamCache;
         _desktopHub = desktopHub;
+        _viewerOptionsProvider = viewerOptionsProvider;
+        _sessionRecordingSink = sessionRecordingSink;
         _logger = logger;
     }
 
@@ -126,6 +133,11 @@ public class ViewerHub : Hub
         }
     }
 
+    public async Task<RemoteControlViewerOptions> GetViewerOptions()
+    {
+        return await _viewerOptionsProvider.GetViewerOptionsAsync(Context, SessionInfo);
+    }
+
     public Task InvokeCtrlAltDel()
     {
         return _hubEvents.InvokeCtrlAltDel(SessionInfo, Context.ConnectionId);
@@ -221,5 +233,21 @@ public class ViewerHub : Hub
         }
 
         return Result.Ok();
+    }
+
+    public async Task StoreSessionRecording(IAsyncEnumerable<byte[]> webmStream)
+    {
+        try
+        {
+            await _sessionRecordingSink.SinkWebmStream(webmStream, Context, SessionInfo);
+        }
+        catch (OperationCanceledException)
+        {
+            _logger.LogInformation("Session recording stopped for stream {streamId}.", SessionInfo.StreamId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error while storing session recording for stream {streamId}.", SessionInfo.StreamId);
+        }
     }
 }

--- a/Immense.RemoteControl.Server/wwwroot/src/App.ts
+++ b/Immense.RemoteControl.Server/wwwroot/src/App.ts
@@ -40,9 +40,9 @@ export const ViewerApp = {
         if (UI.RequesterNameInput.value) {
             ViewerApp.RequesterName = UI.RequesterNameInput.value;
         }
-        else if (ViewerApp.Settings.displayName) {
-            UI.RequesterNameInput.value = ViewerApp.Settings.displayName;
-            ViewerApp.RequesterName = ViewerApp.Settings.displayName;
+        else if (ViewerApp.Settings.DisplayName) {
+            UI.RequesterNameInput.value = ViewerApp.Settings.DisplayName;
+            ViewerApp.RequesterName = ViewerApp.Settings.DisplayName;
         }
 
         if (ViewerApp.Mode == RemoteControlMode.Unattended) {
@@ -74,7 +74,7 @@ export const ViewerApp = {
         ViewerApp.Mode = RemoteControlMode.Attended;
         ViewerApp.ViewerHubConnection.Connect();
 
-        ViewerApp.Settings.displayName = ViewerApp.RequesterName;
+        ViewerApp.Settings.DisplayName = ViewerApp.RequesterName;
         SetSettings(ViewerApp.Settings);
     }
 }

--- a/Immense.RemoteControl.Server/wwwroot/src/InputEventHandlers.ts
+++ b/Immense.RemoteControl.Server/wwwroot/src/InputEventHandlers.ts
@@ -21,7 +21,6 @@ import {
     MenuButton,
     ScreenViewerWrapper,
     WindowsSessionSelect,
-    RecordSessionButton,
     FileTransferMenu,
     FileUploadButtton,
     FileDownloadButton,
@@ -642,18 +641,6 @@ export function ApplyInputHandlers() {
         SetStatusMessage("Switching sessions");
         ShowToast("Switching sessions");
         ViewerApp.MessageSender.ChangeWindowsSession(Number(WindowsSessionSelect.selectedOptions[0].value));
-    });
-    RecordSessionButton.addEventListener("click", () => {
-        RecordSessionButton.classList.toggle("toggled");
-        if (RecordSessionButton.classList.contains("toggled")) {
-            RecordSessionButton.innerHTML = `<i class="fas fa-record-vinyl"> Stop`;
-            ViewerApp.SessionRecorder.Start();
-        }
-        else {
-            RecordSessionButton.innerHTML = `<i class="fas fa-record-vinyl">Record`;
-            ViewerApp.SessionRecorder.Stop();
-            ViewerApp.SessionRecorder.DownloadVideo();
-        }
     });
 
     window.addEventListener("keydown", function (e) {

--- a/Immense.RemoteControl.Server/wwwroot/src/Interfaces/Dtos.ts
+++ b/Immense.RemoteControl.Server/wwwroot/src/Interfaces/Dtos.ts
@@ -134,6 +134,10 @@ export class MouseWheelDto {
     DeltaY: number;
 }
 
+export interface RemoteControlViewerOptions {
+    ShouldRecordSession: boolean;
+}
+
 export interface ScreenDataDto {
     DisplayNames: string[];
     SelectedDisplay: string;

--- a/Immense.RemoteControl.Server/wwwroot/src/Interfaces/Settings.ts
+++ b/Immense.RemoteControl.Server/wwwroot/src/Interfaces/Settings.ts
@@ -1,4 +1,6 @@
-﻿export interface Settings {
-    displayName: string;
-    streamModeEnabled: boolean;
+﻿import { RemoteControlViewerOptions } from "./Dtos.js";
+
+export interface Settings {
+    DisplayName: string;
+    ViewerOptions: RemoteControlViewerOptions;
 }

--- a/Immense.RemoteControl.Server/wwwroot/src/Models/HubConnection.ts
+++ b/Immense.RemoteControl.Server/wwwroot/src/Models/HubConnection.ts
@@ -6,6 +6,7 @@ export type HubConnection = {
     onclose: (callback: () => any) => any;
     state: HubConnectionState;
     invoke<T = void>(...rest): Promise<T>;
+    send(...rest): Promise<void>;
     stop(): Promise<void>;
     stream<T = any>(methodName: string, ...args: any[]): IStreamResult<T>;
 }

--- a/Immense.RemoteControl.Server/wwwroot/src/SessionRecorder.ts
+++ b/Immense.RemoteControl.Server/wwwroot/src/SessionRecorder.ts
@@ -1,69 +1,47 @@
 ﻿import { ScreenViewer } from "./UI.js";
+import { ViewerApp } from "./App.js";
 
 export class SessionRecorder {
-    private Recorder: any;
-    private Stream: MediaStream;
-    private RecordedData: Array<any> = [];
+    private recorder: MediaRecorder;
+    private subject: any;
 
-    Start() {
+    async Start() {
         if (!window["MediaRecorder"] || !ScreenViewer.captureStream) {
-            alert("Session recording isn't supported on this browser.");
+            console.warn("Session recording isn't supported on this browser.");
             return;
         }
 
-        if (this.Recorder && this.Recorder.state != "inactive") {
-            this.Recorder.stop();
+        if (this.recorder && this.recorder.state != "inactive") {
+            this.recorder.stop();
         }
 
-        this.RecordedData = [];
-        this.Stream = ScreenViewer.captureStream(10);
-        var options = { mimeType: 'video/webm' };
-        this.Recorder = new window["MediaRecorder"](this.Stream, options);
-        this.Recorder.ondataavailable = (event) => {
-            if (event.data && event.data.size > 0) {
-                this.RecordedData.push(event.data);
+        const stream = ScreenViewer.captureStream(10);
+        const options = { mimeType: 'video/webm' };
+        this.subject = new window["signalR"].Subject();
+        await ViewerApp.ViewerHubConnection.SendRecordingChunks(this.subject);
+
+        this.recorder = new MediaRecorder(stream, options);
+        
+        this.recorder.ondataavailable = async (event) => {
+            if (!event.data || event.data.size <= 0) {
+                return
+            }
+
+            const buffer = await event.data.arrayBuffer();
+
+            for (let i = 0; i < buffer.byteLength; i += 50_000) {
+
+                const chunk = buffer.slice(i, i + 50_000);
+                const byteArray = new Uint8Array(chunk);
+                this.subject.next(byteArray);
             }
         }
-        this.Recorder.start(100);
+        this.recorder.start(100);
     }
 
     Stop() {
-        if (!this.Recorder) {
-            return;
-        }
-
-        this.Recorder.stop();
+        this.recorder?.stop();
+        this.subject?.complete();
     }
 
-    DownloadVideo() {
-        if (!this.RecordedData || this.RecordedData.length == 0) {
-            alert("No video recorded.");
-            return;
-        }
-
-        if (this.Recorder && this.Recorder.state != "inactive") {
-            alert("You must stop recording before you can download.");
-            return;
-        }
-        var currentDate = new Date();
-        var dateString = `${currentDate.getFullYear()}-` +
-            `${(currentDate.getMonth() + 1).toString().padStart(2, "0")}-` +
-            `${currentDate.getDate().toString().padStart(2, "0")} ` + 
-            `${currentDate.getHours().toString().padStart(2, "0")}.` +
-            `${currentDate.getMinutes().toString().padStart(2, "0")}.` +
-            `${currentDate.getSeconds().toString().padStart(2, "0")}`;
-
-        var blob = new Blob(this.RecordedData, { type: 'video/webm' });
-        var url = window.URL.createObjectURL(blob);
-        var link = document.createElement('a');
-        link.style.display = 'none';
-        link.href = url;
-        link.download = `Remote_Session_${dateString}.webm`;
-        document.body.appendChild(link);
-        link.click();
-        setTimeout(() => {
-            document.body.removeChild(link);
-            window.URL.revokeObjectURL(url);
-        }, 100);
-    }
 }

--- a/Immense.RemoteControl.Server/wwwroot/src/SettingsService.ts
+++ b/Immense.RemoteControl.Server/wwwroot/src/SettingsService.ts
@@ -1,9 +1,12 @@
-﻿import { Settings } from "./Interfaces/Settings.js";
+﻿import { RemoteControlViewerOptions } from "./Interfaces/Dtos.js";
+import { Settings } from "./Interfaces/Settings.js";
 
 const defaultSettings = {
-    streamModeEnabled: false,
-    displayName: ""
-};
+    DisplayName: "",
+    ViewerOptions: {
+        ShouldRecordSession: false
+    } as RemoteControlViewerOptions
+} as Settings;
 
 
 export function GetSettings(): Settings {

--- a/Immense.RemoteControl.Server/wwwroot/src/UI.ts
+++ b/Immense.RemoteControl.Server/wwwroot/src/UI.ts
@@ -41,7 +41,6 @@ export var TypeClipboardButton = document.getElementById("typeClipboardButton") 
 export var ConnectionP2PIcon = document.getElementById("connectionP2PIcon") as HTMLElement;
 export var ConnectionRelayedIcon = document.getElementById("connectionRelayedIcon") as HTMLElement;
 export var WindowsSessionSelect = document.getElementById("windowsSessionSelect") as HTMLSelectElement;
-export var RecordSessionButton = document.getElementById("recordSessionButton") as HTMLButtonElement;
 export var ViewOnlyButton = document.getElementById("viewOnlyButton") as HTMLButtonElement;
 export var FullScreenButton = document.getElementById("fullScreenButton") as HTMLButtonElement;
 export var ToastsWrapper = document.getElementById("toastsWrapper") as HTMLDivElement;
@@ -130,6 +129,7 @@ export function ShowToast(message: string) {
 
 export function ToggleConnectUI(shown: boolean) {
     if (shown) {
+        ConnectButton.innerText = "Connect";
         Screen2DContext.clearRect(0, 0, ScreenViewer.width, ScreenViewer.height);
         ScreenViewerWrapper.setAttribute("hidden", "hidden");
         if (ViewerApp.Mode == RemoteControlMode.Attended) {

--- a/Immense.RemoteControl.Server/wwwroot/src/ViewerHubConnection.ts
+++ b/Immense.RemoteControl.Server/wwwroot/src/ViewerHubConnection.ts
@@ -99,7 +99,7 @@ export class ViewerHubConnection {
     }
 
     // Subject is an interface that comes from the SignalR library.
-    // But we can't use the TypeScript library like we would in in
+    // But we can't use the TypeScript library like we would in
     // React/Vue, so we have to use "any" here.  This won't be an
     // issue when we rewrite the front-end.
     async SendRecordingChunks(subject: any) {

--- a/Immense.RemoteControl.Server/wwwroot/src/ViewerHubConnection.ts
+++ b/Immense.RemoteControl.Server/wwwroot/src/ViewerHubConnection.ts
@@ -12,6 +12,8 @@ import { ProcessStream } from "./CaptureProcessor.js";
 import { HubConnectionState } from "./Enums/HubConnectionState.js";
 import { StreamingState } from "./Models/StreamingState.js";
 import { Result } from "./Models/Result.js";
+import { RemoteControlViewerOptions } from "./Interfaces/Dtos.js";
+import { GetSettings, SetSettings } from "./SettingsService.js";
 
 const MsgPack: MessagePack = window["MessagePack"];
 
@@ -35,7 +37,7 @@ export class ViewerHubConnection {
 
         this.ApplyMessageHandlers(this.Connection);
 
-        this.Connection.start().then(() => {
+        this.Connection.start().then(async () => {
             this.SendScreenCastRequestToDevice();
         }).catch(err => {
             console.error(err.toString());
@@ -57,6 +59,20 @@ export class ViewerHubConnection {
     ChangeWindowsSession(sessionID: number) {
         if (ViewerApp.Mode == RemoteControlMode.Unattended) {
             this.Connection.invoke("ChangeWindowsSession", sessionID);
+        }
+    }
+
+    async GetRemoteControlViewerOptions(): Promise<RemoteControlViewerOptions> {
+        const settings = GetSettings();
+
+        try {
+            settings.ViewerOptions = await this.Connection.invoke<RemoteControlViewerOptions>("GetViewerOptions");
+            SetSettings(settings);
+            return settings.ViewerOptions;
+        }
+        catch (e) {
+            console.error("Error while getting viewer options from server.", e);
+            return settings.ViewerOptions;
         }
     }
 
@@ -82,8 +98,17 @@ export class ViewerHubConnection {
         }
     }
 
+    // Subject is an interface that comes from the SignalR library.
+    // But we can't use the TypeScript library like we would in in
+    // React/Vue, so we have to use "any" here.  This won't be an
+    // issue when we rewrite the front-end.
+    async SendRecordingChunks(subject: any) {
+        await this.Connection.send("StoreSessionRecording", subject);
+    }
 
     async SendScreenCastRequestToDevice() {
+        const viewerOptions = await this.GetRemoteControlViewerOptions();
+
         const result = await this.Connection.invoke<Result>("SendScreenCastRequestToDevice", ViewerApp.SessionId, ViewerApp.AccessKey, ViewerApp.RequesterName);
         if (!result.IsSuccess) {
             this.Connection.stop();
@@ -93,6 +118,10 @@ export class ViewerHubConnection {
 
         const streamingState = new StreamingState();
         ProcessStream(streamingState);
+
+        if (viewerOptions.ShouldRecordSession) {
+            ViewerApp.SessionRecorder.Start();
+        }
 
         this.Connection.stream("GetDesktopStream")
             .subscribe({
@@ -104,6 +133,7 @@ export class ViewerHubConnection {
                     if (!UI.StatusMessage.innerText) {
                         UI.SetStatusMessage("Stream ended.");
                     }
+                    ViewerApp.SessionRecorder.Stop();
                     UI.ToggleConnectUI(true);
                 },
                 error: (err) => {
@@ -112,6 +142,7 @@ export class ViewerHubConnection {
                     if (!UI.StatusMessage.innerText) {
                         UI.SetStatusMessage("Stream ended.");
                     }
+                    ViewerApp.SessionRecorder.Stop();
                     UI.ToggleConnectUI(true);
                 },
             });

--- a/Immense.RemoteControl.Shared/Models/RemoteControlViewerOptions.cs
+++ b/Immense.RemoteControl.Shared/Models/RemoteControlViewerOptions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Immense.RemoteControl.Shared.Models;
+
+[DataContract]
+public class RemoteControlViewerOptions
+{
+    [DataMember]
+    public bool ShouldRecordSession { get; init; }
+}

--- a/Immense.RemoteControl.sln
+++ b/Immense.RemoteControl.sln
@@ -42,7 +42,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Immense.RemoteControl.Deskt
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{23EA60E0-9118-4932-80E5-07C7950720F1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Immense.RemoteControl.Server.Tests", "Tests\Immense.RemoteControl.Server.Tests\Immense.RemoteControl.Server.Tests.csproj", "{2C2534BA-07C8-4AE1-9E2D-DC19E2F7F8CA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Immense.RemoteControl.Server.Tests", "Tests\Immense.RemoteControl.Server.Tests\Immense.RemoteControl.Server.Tests.csproj", "{2C2534BA-07C8-4AE1-9E2D-DC19E2F7F8CA}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Immense.RemoteControl.Desktop.WIndows.Tests", "Tests\Immense.RemoteControl.Desktop.WIndows.Tests\Immense.RemoteControl.Desktop.WIndows.Tests.csproj", "{89DDE049-5AB8-4847-9439-A1DAC6BDB590}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -94,6 +96,10 @@ Global
 		{2C2534BA-07C8-4AE1-9E2D-DC19E2F7F8CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2C2534BA-07C8-4AE1-9E2D-DC19E2F7F8CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2C2534BA-07C8-4AE1-9E2D-DC19E2F7F8CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{89DDE049-5AB8-4847-9439-A1DAC6BDB590}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{89DDE049-5AB8-4847-9439-A1DAC6BDB590}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{89DDE049-5AB8-4847-9439-A1DAC6BDB590}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{89DDE049-5AB8-4847-9439-A1DAC6BDB590}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -104,6 +110,7 @@ Global
 		{9EACF89B-0E6F-480F-BB8F-0EB1E53F9019} = {EEAA61A2-1231-472B-B272-018EB0998EA4}
 		{CE8FF808-9642-4666-8EC6-51F11B8A15CC} = {7653A4E3-AACE-4265-A019-F974D5CAF5A0}
 		{2C2534BA-07C8-4AE1-9E2D-DC19E2F7F8CA} = {23EA60E0-9118-4932-80E5-07C7950720F1}
+		{89DDE049-5AB8-4847-9439-A1DAC6BDB590} = {23EA60E0-9118-4932-80E5-07C7950720F1}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {9FF6EA83-9252-44BF-8D31-E14BF13C3A8B}

--- a/Tests/Immense.RemoteControl.Desktop.WIndows.Tests/EncodingBenchmarks.cs
+++ b/Tests/Immense.RemoteControl.Desktop.WIndows.Tests/EncodingBenchmarks.cs
@@ -1,0 +1,106 @@
+using Immense.RemoteControl.Desktop.Shared.Services;
+using Immense.RemoteControl.Desktop.Windows.Services;
+using Microsoft.Extensions.Logging;
+using Moq;
+using SkiaSharp;
+using System.Diagnostics;
+using System.Drawing;
+using System.Text.RegularExpressions;
+
+namespace Immense.RemoteControl.Desktop.WIndows.Tests;
+
+//[TestClass]
+public class EncodingBenchmarks
+{
+
+    [TestMethod]
+    public async Task CaptureDiff()
+    {
+        var imageHelper = new ImageHelper(Mock.Of<ILogger<ImageHelper>>());
+        var capturer = new ScreenCapturerWin(imageHelper, Mock.Of<ILogger<ScreenCapturerWin>>());
+
+        var totalFrames = 0;
+
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed.TotalSeconds < 5)
+        {
+            var result = capturer.GetNextFrame();
+            if (!result.IsSuccess)
+            {
+                continue;
+            }
+            if (!result.IsSuccess)
+            {
+                await Task.Yield();
+                continue;
+            }
+
+            _ = capturer.GetFrameDiffArea();
+
+            totalFrames++;
+        }
+
+        var fps = (double)totalFrames / 5;
+        Console.WriteLine($"FPS: {fps}");
+    }
+
+
+
+    [TestMethod]
+    public async Task CaptureDiffCropEncode()
+    {
+        var imageHelper = new ImageHelper(Mock.Of<ILogger<ImageHelper>>());
+        var capturer = new ScreenCapturerWin(imageHelper, Mock.Of<ILogger<ScreenCapturerWin>>());
+
+        var totalBytesSent = 0;
+        var totalFrames = 0;
+
+        var sw = Stopwatch.StartNew();
+        while (sw.Elapsed.TotalSeconds < 5)
+        {
+            var result = capturer.GetNextFrame();
+            if (!result.IsSuccess)
+            {
+                continue;
+            }
+            if (!result.IsSuccess)
+            {
+                await Task.Yield();
+                continue;
+            }
+
+            var diffArea = capturer.GetFrameDiffArea();
+
+            if (diffArea.IsEmpty)
+            {
+                await Task.Yield();
+                continue;
+            }
+
+            capturer.CaptureFullscreen = false;
+
+            using var croppedFrame = imageHelper.CropBitmap(result.Value, diffArea);
+
+            var encodedImageBytes = imageHelper.EncodeBitmap(croppedFrame, SKEncodedImageFormat.Jpeg, 80);
+
+            if (encodedImageBytes.Length == 0)
+            {
+                continue;
+            }
+
+            totalBytesSent += encodedImageBytes.Length;
+            totalFrames++;
+        }
+
+        var fps = (double)totalFrames / 5;
+        Console.WriteLine($"FPS: {fps}");
+
+        var megabytes = (double)totalBytesSent / 1024 / 1024;
+        Console.WriteLine($"Total MB: {megabytes:N2}");
+
+        var mbps = (double)totalBytesSent / 5 / 1024 / 1024 * 8;
+        Console.WriteLine($"Mbps: {mbps}");
+    }
+
+}
+

--- a/Tests/Immense.RemoteControl.Desktop.WIndows.Tests/Immense.RemoteControl.Desktop.WIndows.Tests.csproj
+++ b/Tests/Immense.RemoteControl.Desktop.WIndows.Tests/Immense.RemoteControl.Desktop.WIndows.Tests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0-windows</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Immense.RemoteControl.Desktop.Windows\Immense.RemoteControl.Desktop.Windows.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/Immense.RemoteControl.Desktop.WIndows.Tests/Usings.cs
+++ b/Tests/Immense.RemoteControl.Desktop.WIndows.Tests/Usings.cs
@@ -1,0 +1,1 @@
+global using Microsoft.VisualStudio.TestTools.UnitTesting;


### PR DESCRIPTION
This is the initial implementation for server-side session recording.

When a remote session starts, the viewer creates a `MediaStream` (VP9/WEBM format) from the canvas onto which the remote display is being drawn.  This is streamed to the server via SignalR, which uses the consumer's implementation of `ISessionRecordingSink` to persist the stream.

In my tests, the performance seemed to be fine with the recording using the existing connection.  If it becomes a problem, we can create a new one specifically for recording.

The consumer's implementation of `IViewerOptionsProvider` will determine whether sessions should be recorded at all.

The example project implements this by writing the webm files to disk in a subdirectory under the content/bin directory.