### PR TITLE
Refactoring for server-side recording.

### DIFF
--- a/Examples/Immense.RemoteControl.Examples.ServerExample/Services/SessionRecordingSink.cs
+++ b/Examples/Immense.RemoteControl.Examples.ServerExample/Services/SessionRecordingSink.cs
@@ -1,4 +1,4 @@
-﻿using Immense.RemoteControl.Server.Abstractions;
+using Immense.RemoteControl.Server.Abstractions;
 using Immense.RemoteControl.Server.Models;
 using Immense.RemoteControl.Shared.Helpers;
 using Microsoft.AspNetCore.SignalR;
@@ -18,7 +18,6 @@ public class SessionRecordingSink : ISessionRecordingSink
 
     public async Task SinkWebmStream(
         IAsyncEnumerable<byte[]> webmStream, 
-        HubCallerContext hubCallerContext, 
         RemoteControlSession session)
     {
         try
@@ -34,7 +33,7 @@ public class SessionRecordingSink : ISessionRecordingSink
 
             _ = Directory.CreateDirectory(recordingDir);
 
-            var username = PathSanitizer.SanitizeFileName($"{hubCallerContext.User?.Identity?.Name ?? "UnknownUser"}");
+            var username = PathSanitizer.SanitizeFileName($"{session.RequesterName ?? "UnknownUser"}");
             var fileName = 
                 $"{username}_" +
                 $"{DateTimeOffset.Now:yyyyMMdd_HHmmssfff}.webm";

--- a/Examples/Immense.RemoteControl.Examples.ServerExample/Services/ViewerOptionsProvider.cs
+++ b/Examples/Immense.RemoteControl.Examples.ServerExample/Services/ViewerOptionsProvider.cs
@@ -16,8 +16,7 @@ public class ViewerOptionsProvider : IViewerOptionsProvider
         _appSettings = appSettings;
     }
 
-    public Task<RemoteControlViewerOptions> GetViewerOptionsAsync(
-        RemoteControlSession session)
+    public Task<RemoteControlViewerOptions> GetViewerOptions()
     {
         var options = new RemoteControlViewerOptions()
         {

--- a/Examples/Immense.RemoteControl.Examples.ServerExample/Services/ViewerOptionsProvider.cs
+++ b/Examples/Immense.RemoteControl.Examples.ServerExample/Services/ViewerOptionsProvider.cs
@@ -1,4 +1,4 @@
-﻿using Immense.RemoteControl.Examples.ServerExample.Options;
+using Immense.RemoteControl.Examples.ServerExample.Options;
 using Immense.RemoteControl.Server.Abstractions;
 using Immense.RemoteControl.Server.Models;
 using Immense.RemoteControl.Shared.Models;
@@ -17,7 +17,6 @@ public class ViewerOptionsProvider : IViewerOptionsProvider
     }
 
     public Task<RemoteControlViewerOptions> GetViewerOptionsAsync(
-        HubCallerContext hubCallerContext, 
         RemoteControlSession session)
     {
         var options = new RemoteControlViewerOptions()

--- a/Immense.RemoteControl.Desktop.Shared/Startup/CommandProvider.cs
+++ b/Immense.RemoteControl.Desktop.Shared/Startup/CommandProvider.cs
@@ -57,7 +57,7 @@ public static class CommandProvider
         var sessionIdOption = new Option<string>(
            new[] { "-s", "--session-id" },
            "In Unattended mode, this unique session ID will be assigned to this connection and " +
-           $"shared with the server.  The connection can then be found in the RemoteControlSessionCache " +
+           "shared with the server.  The connection can then be found in the RemoteControlSessionCache " +
            "using this ID.");
         rootCommand.AddOption(sessionIdOption);
 

--- a/Immense.RemoteControl.Desktop.Shared/Startup/CommandProvider.cs
+++ b/Immense.RemoteControl.Desktop.Shared/Startup/CommandProvider.cs
@@ -57,7 +57,7 @@ public static class CommandProvider
         var sessionIdOption = new Option<string>(
            new[] { "-s", "--session-id" },
            "In Unattended mode, this unique session ID will be assigned to this connection and " +
-           "shared with the server.  The connection can then be found in the DesktopHubSessionCache " +
+           $"shared with the server.  The connection can then be found in the RemoteControlSessionCache " +
            "using this ID.");
         rootCommand.AddOption(sessionIdOption);
 

--- a/Immense.RemoteControl.Server/Abstractions/IHubEventHandler.cs
+++ b/Immense.RemoteControl.Server/Abstractions/IHubEventHandler.cs
@@ -41,7 +41,7 @@ public interface IHubEventHandler
     Task InvokeCtrlAltDel(RemoteControlSession session, string viewerConnectionId);
 
     /// <summary>
-    /// This is called when a new session is added to the <see cref="IDesktopHubSessionCache"/>.
+    /// This is called when a new session is added to the <see cref="IRemoteControlSessionCache"/>.
     /// </summary>
     /// <param name="sessionInfo"></param>
     /// <returns></returns>
@@ -49,7 +49,7 @@ public interface IHubEventHandler
 
     /// <summary>
     /// This is called when all viewers have left a remote control session
-    /// and the session is removed from the <see cref="IDesktopHubSessionCache"/>.
+    /// and the session is removed from the <see cref="IRemoteControlSessionCache"/>.
     /// </summary>
     /// <param name="sessionInfo"></param>
     /// <returns></returns>

--- a/Immense.RemoteControl.Server/Abstractions/ISessionRecordingSink.cs
+++ b/Immense.RemoteControl.Server/Abstractions/ISessionRecordingSink.cs
@@ -1,4 +1,4 @@
-﻿using Immense.RemoteControl.Server.Models;
+using Immense.RemoteControl.Server.Models;
 using Microsoft.AspNetCore.SignalR;
 using System;
 using System.Collections.Generic;
@@ -15,7 +15,6 @@ public interface ISessionRecordingSink
 {
     /// <summary>
     /// Sink a live webm stream to persistent storage. 
-    /// The HubCallerContext is that of the viewer.
     /// </summary>
     /// <param name="webmStream"></param>
     /// <param name="hubCallerContext"></param>
@@ -23,6 +22,5 @@ public interface ISessionRecordingSink
     /// <returns></returns>
     Task SinkWebmStream(
         IAsyncEnumerable<byte[]> webmStream,
-        HubCallerContext hubCallerContext,
         RemoteControlSession session);
 }

--- a/Immense.RemoteControl.Server/Abstractions/IViewerOptionsProvider.cs
+++ b/Immense.RemoteControl.Server/Abstractions/IViewerOptionsProvider.cs
@@ -1,4 +1,4 @@
-﻿using Immense.RemoteControl.Server.Models;
+using Immense.RemoteControl.Server.Models;
 using Immense.RemoteControl.Shared.Models;
 using Microsoft.AspNetCore.SignalR;
 using System;
@@ -14,6 +14,5 @@ namespace Immense.RemoteControl.Server.Abstractions;
 /// </summary>
 public interface IViewerOptionsProvider
 {
-    Task<RemoteControlViewerOptions> GetViewerOptionsAsync(
-        RemoteControlSession session);
+    Task<RemoteControlViewerOptions> GetViewerOptions();
 }

--- a/Immense.RemoteControl.Server/Abstractions/IViewerOptionsProvider.cs
+++ b/Immense.RemoteControl.Server/Abstractions/IViewerOptionsProvider.cs
@@ -15,6 +15,5 @@ namespace Immense.RemoteControl.Server.Abstractions;
 public interface IViewerOptionsProvider
 {
     Task<RemoteControlViewerOptions> GetViewerOptionsAsync(
-        HubCallerContext hubCallerContext,
         RemoteControlSession session);
 }

--- a/Immense.RemoteControl.Server/Extensions/ServiceCollectionExtensions.cs
+++ b/Immense.RemoteControl.Server/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Immense.RemoteControl.Server.Filters;
+using Immense.RemoteControl.Server.Filters;
 using Immense.RemoteControl.Server.Services;
 using Immense.RemoteControl.Shared.Services;
 using Microsoft.Extensions.DependencyInjection;
@@ -30,9 +30,9 @@ public static class ServiceCollectionExtensions
             })
             .AddMessagePackProtocol();
 
-        services.AddHostedService<DesktopHubSessionCleaner>();
+        services.AddHostedService<RemoteControlSessionCleaner>();
         services.AddSingleton<IDesktopStreamCache, DesktopStreamCache>();
-        services.AddSingleton<IDesktopHubSessionCache, DesktopHubSessionCache>();
+        services.AddSingleton<IRemoteControlSessionCache, RemoteControlSessionCache>();
         services.AddSingleton<ISystemTime, SystemTime>();
         services.AddScoped<ViewerAuthorizationFilter>();
 

--- a/Immense.RemoteControl.Server/Hubs/DesktopHub.cs
+++ b/Immense.RemoteControl.Server/Hubs/DesktopHub.cs
@@ -12,11 +12,11 @@ public class DesktopHub : Hub
 {
     private readonly IHubEventHandler _hubEvents;
     private readonly ILogger<DesktopHub> _logger;
-    private readonly IDesktopHubSessionCache _sessionCache;
+    private readonly IRemoteControlSessionCache _sessionCache;
     private readonly IDesktopStreamCache _streamCache;
     private readonly IHubContext<ViewerHub> _viewerHub;
     public DesktopHub(
-        IDesktopHubSessionCache sessionCache,
+        IRemoteControlSessionCache sessionCache,
         IDesktopStreamCache streamCache,
         IHubContext<ViewerHub> viewerHubContext,
         IHubEventHandler hubEvents,

--- a/Immense.RemoteControl.Server/Hubs/ViewerHub.cs
+++ b/Immense.RemoteControl.Server/Hubs/ViewerHub.cs
@@ -135,7 +135,18 @@ public class ViewerHub : Hub
 
     public async Task<RemoteControlViewerOptions> GetViewerOptions()
     {
-        return await _viewerOptionsProvider.GetViewerOptionsAsync(SessionInfo);
+        try
+        {
+            return await _viewerOptionsProvider.GetViewerOptionsAsync(SessionInfo);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error getting viewer options.");
+            return new()
+            {
+                ShouldRecordSession = false
+            };
+        }
     }
 
     public Task InvokeCtrlAltDel()

--- a/Immense.RemoteControl.Server/Hubs/ViewerHub.cs
+++ b/Immense.RemoteControl.Server/Hubs/ViewerHub.cs
@@ -135,18 +135,7 @@ public class ViewerHub : Hub
 
     public async Task<RemoteControlViewerOptions> GetViewerOptions()
     {
-        try
-        {
-            return await _viewerOptionsProvider.GetViewerOptionsAsync(SessionInfo);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error getting viewer options.");
-            return new()
-            {
-                ShouldRecordSession = false
-            };
-        }
+        return await _viewerOptionsProvider.GetViewerOptions();
     }
 
     public Task InvokeCtrlAltDel()

--- a/Immense.RemoteControl.Server/Hubs/ViewerHub.cs
+++ b/Immense.RemoteControl.Server/Hubs/ViewerHub.cs
@@ -16,14 +16,14 @@ public class ViewerHub : Hub
     private readonly IHubContext<DesktopHub> _desktopHub;
     private readonly IViewerOptionsProvider _viewerOptionsProvider;
     private readonly ISessionRecordingSink _sessionRecordingSink;
-    private readonly IDesktopHubSessionCache _desktopSessionCache;
+    private readonly IRemoteControlSessionCache _desktopSessionCache;
     private readonly IHubEventHandler _hubEvents;
     private readonly ILogger<ViewerHub> _logger;
     private readonly IDesktopStreamCache _streamCache;
 
     public ViewerHub(
         IHubEventHandler hubEvents,
-        IDesktopHubSessionCache desktopSessionCache,
+        IRemoteControlSessionCache desktopSessionCache,
         IDesktopStreamCache streamCache,
         IHubContext<DesktopHub> desktopHub,
         IViewerOptionsProvider viewerOptionsProvider,
@@ -135,7 +135,7 @@ public class ViewerHub : Hub
 
     public async Task<RemoteControlViewerOptions> GetViewerOptions()
     {
-        return await _viewerOptionsProvider.GetViewerOptionsAsync(Context, SessionInfo);
+        return await _viewerOptionsProvider.GetViewerOptionsAsync(SessionInfo);
     }
 
     public Task InvokeCtrlAltDel()

--- a/Immense.RemoteControl.Server/Hubs/ViewerHub.cs
+++ b/Immense.RemoteControl.Server/Hubs/ViewerHub.cs
@@ -239,7 +239,7 @@ public class ViewerHub : Hub
     {
         try
         {
-            await _sessionRecordingSink.SinkWebmStream(webmStream, Context, SessionInfo);
+            await _sessionRecordingSink.SinkWebmStream(webmStream, SessionInfo);
         }
         catch (OperationCanceledException)
         {

--- a/Immense.RemoteControl.Server/Models/RemoteControlSession.cs
+++ b/Immense.RemoteControl.Server/Models/RemoteControlSession.cs
@@ -1,7 +1,14 @@
 using Immense.RemoteControl.Shared.Helpers;
+using Immense.RemoteControl.Server.Services;
 
 namespace Immense.RemoteControl.Server.Models;
 
+/// <summary>
+/// Contains data related to a remote control session.  Consuming projects
+/// are expected to derive a class from this and add project-specific properties.
+/// They should add these derived classes to<see cref="IRemoteControlSessionCache"/>
+/// when sessions are created.
+/// </summary>
 public class RemoteControlSession : IDisposable
 {
     private readonly ManualResetEventSlim _sessionReadySignal = new(false);

--- a/Immense.RemoteControl.Server/Services/RemoteControlSessionCache.cs
+++ b/Immense.RemoteControl.Server/Services/RemoteControlSessionCache.cs
@@ -8,7 +8,10 @@ using System.Text.Json;
 
 namespace Immense.RemoteControl.Server.Services;
 
-public interface IDesktopHubSessionCache
+/// <summary>
+/// A cache containing all active remote control sessions.
+/// </summary>
+public interface IRemoteControlSessionCache
 {
     IEnumerable<RemoteControlSession> Sessions { get; }
     RemoteControlSession AddOrUpdate(string sessionId, RemoteControlSession session);
@@ -25,7 +28,7 @@ public interface IDesktopHubSessionCache
     bool TryRemove(string sessionId, [NotNullWhen(true)] out RemoteControlSession? session);
 }
 
-internal class DesktopHubSessionCache : IDesktopHubSessionCache
+internal class RemoteControlSessionCache : IRemoteControlSessionCache
 {
     private readonly ConcurrentDictionary<string, RemoteControlSession> _sessions = new();
     // ConcurrentDictionary's AddOrUpdate and GetOrAdd are not atomic operations,
@@ -33,12 +36,13 @@ internal class DesktopHubSessionCache : IDesktopHubSessionCache
     private readonly object _sessionsLock = new();
 
     private readonly IHubEventHandler _hubEventHandler;
-    private readonly ILogger<DesktopHubSessionCache> _logger;
+    private readonly ILogger<RemoteControlSessionCache> _logger;
     private readonly ISystemTime _systemTime;
-    public DesktopHubSessionCache(
+
+    public RemoteControlSessionCache(
         ISystemTime systemTime,
         IHubEventHandler hubEventHandler,
-        ILogger<DesktopHubSessionCache> logger)
+        ILogger<RemoteControlSessionCache> logger)
     {
         _systemTime = systemTime;
         _hubEventHandler = hubEventHandler;

--- a/Immense.RemoteControl.Server/Services/RemoteControlSessionCleaner.cs
+++ b/Immense.RemoteControl.Server/Services/RemoteControlSessionCleaner.cs
@@ -1,19 +1,18 @@
-﻿using Immense.RemoteControl.Server.Hubs;
+using Immense.RemoteControl.Server.Hubs;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
 namespace Immense.RemoteControl.Server.Services;
 
-public class DesktopHubSessionCleaner : BackgroundService
+public class RemoteControlSessionCleaner : BackgroundService
 {
-    private readonly IDesktopHubSessionCache _sessionCache;
-    private readonly ILogger<DesktopHubSessionCleaner> _logger;
+    private readonly IRemoteControlSessionCache _sessionCache;
+    private readonly ILogger<RemoteControlSessionCleaner> _logger;
 
-    public DesktopHubSessionCleaner(
-        IHubContext<DesktopHub> desktopHub,
-        IDesktopHubSessionCache sessionCache,
-        ILogger<DesktopHubSessionCleaner> logger)
+    public RemoteControlSessionCleaner(
+        IRemoteControlSessionCache sessionCache,
+        ILogger<RemoteControlSessionCleaner> logger)
     {
         _sessionCache = sessionCache;
         _logger = logger;

--- a/Immense.RemoteControl.Server/wwwroot/src/ViewerHubConnection.ts
+++ b/Immense.RemoteControl.Server/wwwroot/src/ViewerHubConnection.ts
@@ -107,9 +107,14 @@ export class ViewerHubConnection {
     }
 
     async SendScreenCastRequestToDevice() {
-        const viewerOptions = await this.GetRemoteControlViewerOptions();
+      const viewerOptions = await this.GetRemoteControlViewerOptions();
 
-        const result = await this.Connection.invoke<Result>("SendScreenCastRequestToDevice", ViewerApp.SessionId, ViewerApp.AccessKey, ViewerApp.RequesterName);
+      const result = await this.Connection.invoke<Result>(
+        "SendScreenCastRequestToDevice",
+        ViewerApp.SessionId,
+        ViewerApp.AccessKey,
+        ViewerApp.RequesterName);
+
         if (!result.IsSuccess) {
             this.Connection.stop();
             UI.SetStatusMessage(result.Reason);

--- a/Immense.RemoteControl.Shared/Helpers/RandomGenerator.cs
+++ b/Immense.RemoteControl.Shared/Helpers/RandomGenerator.cs
@@ -1,4 +1,4 @@
-﻿using System.Security.Cryptography;
+using System.Security.Cryptography;
 
 namespace Immense.RemoteControl.Shared.Helpers;
 
@@ -8,12 +8,7 @@ public class RandomGenerator
 
     public static string GenerateString(int length)
     {
-        var bytes = new byte[length];
-        using (var random = RandomNumberGenerator.Create())
-        {
-            random.GetBytes(bytes);
-        }
-
+        var bytes = RandomNumberGenerator.GetBytes(length);
         return new string(bytes.Select(x => AllowableCharacters[x % AllowableCharacters.Length]).ToArray());
     }
 

--- a/Tests/Immense.RemoteControl.Server.Tests/RemoteControlSessionCacheTests.cs
+++ b/Tests/Immense.RemoteControl.Server.Tests/RemoteControlSessionCacheTests.cs
@@ -10,13 +10,13 @@ using Moq;
 namespace Immense.RemoteControl.Server.Tests;
 
 [TestClass]
-public class DesktopHubSessionCacheTests
+public class RemoteControlSessionCacheTests
 {
 #nullable disable
     private SystemTime _systemTime;
     private Mock<IHubEventHandler> _hubEventHandler;
-    private Mock<ILogger<DesktopHubSessionCache>> _logger;
-    private DesktopHubSessionCache _sessionCache;
+    private Mock<ILogger<RemoteControlSessionCache>> _logger;
+    private RemoteControlSessionCache _sessionCache;
 #nullable enable
 
     [TestInitialize]
@@ -24,9 +24,9 @@ public class DesktopHubSessionCacheTests
     {
         _systemTime = new SystemTime();
         _hubEventHandler = new Mock<IHubEventHandler>();
-        _logger = new Mock<ILogger<DesktopHubSessionCache>>();
+        _logger = new Mock<ILogger<RemoteControlSessionCache>>();
 
-        _sessionCache = new DesktopHubSessionCache(_systemTime, _hubEventHandler.Object, _logger.Object);
+        _sessionCache = new RemoteControlSessionCache(_systemTime, _hubEventHandler.Object, _logger.Object);
     }
 
     [TestMethod]


### PR DESCRIPTION
A few refactors while working on session recording in Immy.

- Renamed `IDesktopHubSessionCache` to `IRemoteControlSessionCache`.
- Removed `HubCallerContext` from interfaces.