### PR TITLE
Strongly-typed circuit events in Remotely.

### DIFF
--- a/Immense.RemoteControl.Shared/Immense.RemoteControl.Shared.csproj
+++ b/Immense.RemoteControl.Shared/Immense.RemoteControl.Shared.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Immense.SimpleMessenger" Version="1.0.0" />
+    <PackageReference Include="Immense.SimpleMessenger" Version="1.1.0" />
     <PackageReference Include="MessagePack" Version="2.5.124" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
   </ItemGroup>


### PR DESCRIPTION
I needed to update the `SimpleMessenger` package for Remotely.  There was a lock exception occurring within SignalR methods that used streaming.