### PR TITLE
Lock Moq version at 4.18.4.

### DIFF
--- a/Tests/Immense.RemoteControl.Desktop.WIndows.Tests/Immense.RemoteControl.Desktop.WIndows.Tests.csproj
+++ b/Tests/Immense.RemoteControl.Desktop.WIndows.Tests/Immense.RemoteControl.Desktop.WIndows.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0-windows</TargetFramework>
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="[4.18.4]" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
     <PackageReference Include="coverlet.collector" Version="3.2.0" />

--- a/Tests/Immense.RemoteControl.Server.Tests/Immense.RemoteControl.Server.Tests.csproj
+++ b/Tests/Immense.RemoteControl.Server.Tests/Immense.RemoteControl.Server.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net7.0</TargetFramework>
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-    <PackageReference Include="Moq" Version="4.18.4" />
+    <PackageReference Include="Moq" Version="[4.18.4]" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.0.4" />
     <PackageReference Include="MSTest.TestFramework" Version="3.0.4" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">


### PR DESCRIPTION
This PR locks the version of Moq at 4.18.4.  This is the last version before the SponsorLink debacle happened.  We'll probably switch to NSubstitute later.

More info here:  https://github.com/moq/moq/issues/1372

