### PR TITLE
Add platform guards for Windows APIs.

### DIFF
--- a/Examples/Immense.RemoteControl.Examples.LinuxDesktopExample/BrandingProvider.cs
+++ b/Examples/Immense.RemoteControl.Examples.LinuxDesktopExample/BrandingProvider.cs
@@ -10,18 +10,21 @@ internal class BrandingProvider : IBrandingProvider
         Product = "Immy Remote"
     };
 
-    public BrandingProvider()
-    {
-        using var mrs = typeof(BrandingProvider).Assembly.GetManifestResourceStream("Immense.RemoteControl.Examples.LinuxDesktopExample.ImmyBot.png");
-        using var ms = new MemoryStream();
-        mrs!.CopyTo(ms);
 
-        _brandingInfo.Icon = ms.ToArray();
-    }
+    public BrandingInfoBase CurrentBranding => _brandingInfo;
 
     public Task<BrandingInfoBase> GetBrandingInfo()
     {
         return Task.FromResult(_brandingInfo);
+    }
+
+    public async Task Initialize()
+    {
+        using var mrs = typeof(BrandingProvider).Assembly.GetManifestResourceStream("Immense.RemoteControl.Examples.LinuxDesktopExample.ImmyBot.png");
+        using var ms = new MemoryStream();
+        await mrs!.CopyToAsync(ms);
+
+        _brandingInfo.Icon = ms.ToArray();
     }
 
     public void SetBrandingInfo(BrandingInfoBase brandingInfo)

--- a/Examples/Immense.RemoteControl.Examples.WindowsDesktopExample/BrandingProvider.cs
+++ b/Examples/Immense.RemoteControl.Examples.WindowsDesktopExample/BrandingProvider.cs
@@ -10,18 +10,21 @@ internal class BrandingProvider : IBrandingProvider
         Product = "Immy Remote"
     };
 
-    public BrandingProvider()
-    {
-        using var mrs = typeof(BrandingProvider).Assembly.GetManifestResourceStream("Immense.RemoteControl.Examples.WindowsDesktopExample.ImmyBot.png");
-        using var ms = new MemoryStream();
-        mrs!.CopyTo(ms);
 
-        _brandingInfo.Icon = ms.ToArray();
-    }
+    public BrandingInfoBase CurrentBranding => _brandingInfo;
 
     public Task<BrandingInfoBase> GetBrandingInfo()
     {
         return Task.FromResult(_brandingInfo);
+    }
+
+    public async Task Initialize()
+    {
+        using var mrs = typeof(BrandingProvider).Assembly.GetManifestResourceStream("Immense.RemoteControl.Examples.WindowsDesktopExample.ImmyBot.png");
+        using var ms = new MemoryStream();
+        await mrs!.CopyToAsync(ms);
+
+        _brandingInfo.Icon = ms.ToArray();
     }
 
     public void SetBrandingInfo(BrandingInfoBase brandingInfo)

--- a/Immense.RemoteControl.Desktop.Windows/Services/CursorIconWatcherWin.cs
+++ b/Immense.RemoteControl.Desktop.Windows/Services/CursorIconWatcherWin.cs
@@ -1,11 +1,10 @@
-﻿using Avalonia.Controls;
-using Immense.RemoteControl.Desktop.Shared.Abstractions;
+﻿using Immense.RemoteControl.Desktop.Shared.Abstractions;
 using Immense.RemoteControl.Desktop.Shared.Native.Windows;
 using Immense.RemoteControl.Shared.Models;
 using System.Drawing;
 using System.Drawing.Imaging;
-using System.IO;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using System.Timers;
 
 namespace Immense.RemoteControl.Desktop.Windows.Services;
@@ -13,6 +12,7 @@ namespace Immense.RemoteControl.Desktop.Windows.Services;
 /// <summary>
 /// A class that can be used to watch for cursor icon changes.
 /// </summary>
+[SupportedOSPlatform("windows")]
 public class CursorIconWatcherWin : ICursorIconWatcher
 {
     private const int IBeamHandle = 65541;

--- a/Immense.RemoteControl.Desktop.Windows/Services/KeyboardMouseInputWin.cs
+++ b/Immense.RemoteControl.Desktop.Windows/Services/KeyboardMouseInputWin.cs
@@ -8,10 +8,12 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 using static Immense.RemoteControl.Desktop.Shared.Native.Windows.User32;
 
 namespace Immense.RemoteControl.Desktop.Windows.Services;
 
+[SupportedOSPlatform("windows")]
 public class KeyboardMouseInputWin : IKeyboardMouseInput
 {
     private readonly IUiDispatcher _dispatcher;

--- a/Immense.RemoteControl.Desktop.Windows/Services/MessageLoop.cs
+++ b/Immense.RemoteControl.Desktop.Windows/Services/MessageLoop.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using Immense.SimpleMessenger;
 using Immense.RemoteControl.Desktop.UI.Services;
 using System.Runtime.InteropServices;
+using System.Runtime.Versioning;
 
 namespace Immense.RemoteControl.Desktop.Windows.Services;
 
@@ -15,6 +16,7 @@ public interface IMessageLoop
     void StartMessageLoop();
 }
 
+[SupportedOSPlatform("windows")]
 public class MessageLoop : IMessageLoop
 {
     private readonly ILogger<MessageLoop> _logger;

--- a/Immense.RemoteControl.Desktop.Windows/Services/ScreenCapturerWin.cs
+++ b/Immense.RemoteControl.Desktop.Windows/Services/ScreenCapturerWin.cs
@@ -39,9 +39,11 @@ using Immense.RemoteControl.Desktop.Windows.Models;
 using Immense.RemoteControl.Desktop.Shared.Native.Windows;
 using System.Drawing;
 using Immense.RemoteControl.Desktop.Windows.Helpers;
+using System.Runtime.Versioning;
 
 namespace Immense.RemoteControl.Desktop.Windows.Services;
 
+[SupportedOSPlatform("windows")]
 public class ScreenCapturerWin : IScreenCapturer
 {
     private readonly Dictionary<string, int> _bitBltScreens = new();

--- a/Immense.RemoteControl.Desktop.Windows/Startup/IServiceCollectionExtensions.cs
+++ b/Immense.RemoteControl.Desktop.Windows/Startup/IServiceCollectionExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Immense.RemoteControl.Desktop.Shared.Startup;
 using Immense.RemoteControl.Desktop.Windows.Services;
 using Immense.RemoteControl.Desktop.UI.Startup;
+using System.Runtime.Versioning;
 
 namespace Immense.RemoteControl.Desktop.Windows.Startup;
 
@@ -15,6 +16,7 @@ public static class IServiceCollectionExtensions
     /// </summary>
     /// <param name="services"></param>
     /// <param name="clientConfig"></param>
+    [SupportedOSPlatform("windows")]
     public static void AddRemoteControlWindows(
         this IServiceCollection services,
         Action<IRemoteControlClientBuilder> clientConfig)

--- a/Tests/Immense.RemoteControl.Desktop.WIndows.Tests/EncodingBenchmarks.cs
+++ b/Tests/Immense.RemoteControl.Desktop.WIndows.Tests/EncodingBenchmarks.cs
@@ -1,11 +1,9 @@
 using Immense.RemoteControl.Desktop.Shared.Services;
-using Immense.RemoteControl.Immense.RemoteControl.Desktop.Windows.Services;
+using Immense.RemoteControl.Desktop.Windows.Services;
 using Microsoft.Extensions.Logging;
 using Moq;
 using SkiaSharp;
 using System.Diagnostics;
-using System.Drawing;
-using System.Text.RegularExpressions;
 
 namespace Immense.RemoteControl.Desktop.WIndows.Tests;
 


### PR DESCRIPTION
The Windows project no longer explicitly targets Windows, so platform guards are needed to prevent warnings. I also set this warning to be treated as an error.